### PR TITLE
Fixed model data not being transferred to query term component

### DIFF
--- a/src/app/query/containers/m3d/m3d-query-term.component.ts
+++ b/src/app/query/containers/m3d/m3d-query-term.component.ts
@@ -138,7 +138,7 @@ export class M3DQueryTermComponent {
    */
   private openM3DDialog(data?: any) {
     let dialogRef = this.dialog.open(M3DLoaderDialogComponent, {data: data});
-    dialogRef.afterClosed().pipe(first()).subscribe((result: Mesh) => {
+    dialogRef.beforeClosed().pipe(first()).subscribe((result: Mesh) => {
       if (result) {
         this.preview.setMesh(result);
         this.preview.render();

--- a/src/config.json
+++ b/src/config.json
@@ -15,7 +15,7 @@
     "options": {
       "image": true,
       "audio": true,
-      "model3d": false,
+      "model3d": true,
       "motion": false,
       "text": true,
       "tag": true,


### PR DESCRIPTION
# Description

I wanted to test a new 3D model feature extractor and thus tried to test it with some queries using Vitrivr NG.
However, after adding a 3D model query term, loading an OBJ model and then clicking the dialog's save button, the model isn't transferred over to the 3D model query term (query term menu on the left side). This causes the query to fail because an empty query/no model data is sent to Cineast.

# Are there any open issues?

No.

# How Has This Been Tested?

Steps to reproduce:
1) Add 3D model query term
2) Click on black square to open dialog
3) Load an OBJ model
4) Click the dialog's save button
5) The model fails to load/transfer over to the 3D model query term

How the fix was tested:
Run steps to reproduce again after the fix. The model is successfully transferred over to the 3D model query term.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (wiki, README, Website)
- [ ] I have updated the pre-built binary on the release page (for major changes)
