### PR TITLE
avoid freezes: limit rerank and next calls

### DIFF
--- a/src/app/core/queries/query.service.ts
+++ b/src/app/core/queries/query.service.ts
@@ -348,9 +348,10 @@ export class QueryService {
   private finalizeQuery(queryId: string) {
     if (this._interval_map.has(queryId)) {
       window.clearInterval(this._interval_map.get(queryId));
+      this._interval_map.delete(queryId);
     }
     // be sure that updates are checked one last time
-    this._results.checkUpdate();
+    this._results.doUpdate();
     this._running -= 1;
     this._subject.next('ENDED' as QueryChange);
     if (this._results.segmentCount > 0) {
@@ -366,6 +367,7 @@ export class QueryService {
   private errorOccurred(message: QueryError) {
     if (this._interval_map.has(message.queryId)) {
       window.clearInterval(this._interval_map.get(message.queryId));
+      this._interval_map.delete(message.queryId);
     }
     this._running -= 1;
     this._subject.next('ERROR' as QueryChange);

--- a/src/app/core/queries/query.service.ts
+++ b/src/app/core/queries/query.service.ts
@@ -53,6 +53,8 @@ export class QueryService {
 
   /** Results of a query. May be empty. */
   private _results: ResultsContainer;
+  /** Rerank handler of the ResultsContainer. */
+  private _interval: number;
 
   /** Flag indicating whether a query is currently being executed. */
   private _running = 0;
@@ -329,6 +331,7 @@ export class QueryService {
     /* Start the actual query. */
     if (!this._results || (this._results && this._results.queryId !== queryId)) {
       this._results = new ResultsContainer(queryId);
+      this._interval = setInterval(() => this._results.checkUpdate(), 2500);
       if (this._scoreFunction) {
         this._results.setScoreFunction(this._scoreFunction);
       }
@@ -343,6 +346,8 @@ export class QueryService {
    * This method triggers an observable change in the QueryService class.
    */
   private finalizeQuery() {
+    // be sure that rerank has runned one last time
+    setTimeout(() => clearInterval(this._interval), 2500);
     this._running -= 1;
     this._subject.next('ENDED' as QueryChange);
     if (this._results.segmentCount > 0) {

--- a/src/app/shared/model/results/scores/results-container.model.ts
+++ b/src/app/shared/model/results/scores/results-container.model.ts
@@ -49,6 +49,11 @@ export class ResultsContainer {
   /** A subject that can be used to publish changes to the results. */
   private _results_segments_subject: BehaviorSubject<SegmentScoreContainer[]> = new BehaviorSubject(this._results_segments);
 
+  /** A counter for rerank() requests. So we don't have to loop over all objects and segments many times per second. */
+  private _rerank: number = 0;
+  /** A counter for next() requests. So we don't have to loop over all objects and segments many times per second. */
+  private _next: number = 0;
+
   /**
    * Constructor for ResultsContainer.
    *
@@ -56,6 +61,25 @@ export class ResultsContainer {
    * @param {FusionFunction} scoreFunction Function that should be used to calculate the scores.
    */
   constructor(public readonly queryId: string, private scoreFunction: FusionFunction = TemporalFusionFunction.instance()) {
+  }
+
+  public checkUpdate() {
+    // set upper limit, to avoid call in avalanche of responses
+    if (this._rerank > 0) {
+      // check upper limit to avoid call in avalanche of responses
+      if (this._rerank < 20) {
+        this.rerank();
+      } else { // mark unranked changes for next round
+        this._rerank = 1;
+      }
+    } else if (this._next > 0) {
+      // check upper limit to avoid call in avalanche of responses
+      if (this._next < 20) {
+        this.next();
+      } else { // mark unpublished changes for next round
+        this._next = 1;
+      }
+    }
   }
 
   /** List of all the results that were returned and hence are known to the results container. */
@@ -276,6 +300,7 @@ export class ResultsContainer {
    * @param {FusionFunction} weightFunction
    */
   public rerank(features?: WeightedFeatureCategory[], weightFunction?: FusionFunction) {
+    this._rerank = 0;
     if (!features) {
       console.debug(`no features given for rerank(), using features inherent to the results container: ${this.features}`);
       features = this.features;
@@ -323,7 +348,7 @@ export class ResultsContainer {
     }
 
     /* Re-rank on the UI side - this also invokes next(). */
-    this.rerank();
+    this._rerank += 1;
 
     /* Return true. */
     return true;
@@ -353,7 +378,7 @@ export class ResultsContainer {
     }
 
     /* Re-rank on the UI side - this also invokes next(). */
-    this.rerank();
+    this._rerank += 1;
 
     /* Return true. */
     return true;
@@ -376,7 +401,7 @@ export class ResultsContainer {
       }
     }
 
-    this.next()
+    this._next += 1;
   }
 
   /**
@@ -396,7 +421,7 @@ export class ResultsContainer {
       }
     }
 
-    this.next()
+    this._next += 1;
   }
 
   /**
@@ -425,7 +450,7 @@ export class ResultsContainer {
 
 
     /* Re-rank the results (calling this method also causes an invocation of next(). */
-    this.rerank();
+    this._rerank += 1;
     return true;
   }
 
@@ -476,6 +501,7 @@ export class ResultsContainer {
    * Publishes the next rounds of changes by pushing the filtered array to the respective subjects.
    */
   private next() {
+    this._next = 0;
     this._results_segments_subject.next(this._results_segments.filter(v => v.objectScoreContainer.show)); /* Filter segments that are not ready. */
     this._results_objects_subject.next(this._results_objects.filter(v => v.show));
     this._results_features_subject.next(this._features);

--- a/src/app/shared/model/results/scores/results-container.model.ts
+++ b/src/app/shared/model/results/scores/results-container.model.ts
@@ -67,14 +67,14 @@ export class ResultsContainer {
     // set upper limit, to avoid call in avalanche of responses
     if (this._rerank > 0) {
       // check upper limit to avoid call in avalanche of responses
-      if (this._rerank < 20) {
+      if (this._rerank < 100) {
         this.rerank();
       } else { // mark unranked changes for next round
         this._rerank = 1;
       }
     } else if (this._next > 0) {
       // check upper limit to avoid call in avalanche of responses
-      if (this._next < 20) {
+      if (this._next < 100) {
         this.next();
       } else { // mark unpublished changes for next round
         this._next = 1;

--- a/src/app/shared/model/results/scores/results-container.model.ts
+++ b/src/app/shared/model/results/scores/results-container.model.ts
@@ -64,7 +64,6 @@ export class ResultsContainer {
   }
 
   public checkUpdate() {
-    // set upper limit, to avoid call in avalanche of responses
     if (this._rerank > 0) {
       // check upper limit to avoid call in avalanche of responses
       if (this._rerank < 100) {
@@ -72,13 +71,22 @@ export class ResultsContainer {
       } else { // mark unranked changes for next round
         this._rerank = 1;
       }
-    } else if (this._next > 0) {
+    } else if (this._next > 0) { // else if as rerank already calls next
       // check upper limit to avoid call in avalanche of responses
       if (this._next < 100) {
         this.next();
       } else { // mark unpublished changes for next round
         this._next = 1;
       }
+    }
+  }
+
+  // force update if there are changes, e.g. on query end
+  public doUpdate() {
+    if (this._rerank > 0) {
+      this.rerank();
+    } else if (this._next > 0) { // else if as rerank already calls next
+      this.next();
     }
   }
 


### PR DESCRIPTION
Actually, on every call of  
* processObjectMessage()
* processSegmentMessage()
* processSimilarityMessage()

as well as  
* processSegmentMetadataMessage()
* processObjectMetadataMessage()

we call rerank() and next() respectively. As all these messages are incoming almost simultaniously, often some thousand responses together, the whole UI freezes for a long time (during the whole query which can take some minutes). And as rerank and next are very intensive to compute (we loop over all objects, therin over all segments to calculate costs etc), the freeze is clear to happen. So instead of calling rerank and next some thousand times per second, I use a counter. If there were changes during the last time frame, we call these methods once. 