### PR TITLE
prevent vbs crash on http error

### DIFF
--- a/src/app/core/vbs/vbs-submission.service.ts
+++ b/src/app/core/vbs/vbs-submission.service.ts
@@ -234,23 +234,28 @@ export class VbsSubmissionService {
 
         /* Do some logging and catch HTTP errors. */
         return observable.pipe(
-          tap(o => console.log(`Submitting element to server; id: ${id}`)),
-          catchError((err) => of(`Failed to submit segment to VBS due to a HTTP error (${err.status}).`))
+          tap(o => console.log(`Submitting element to server; id: ${id}`), err => console.log(`Failed to submit segment to VBS due to a HTTP error (${err.status}).`)),
+          catchError(err => of(err.error))
         );
       }),
       map((msg: string) => {
           console.log(msg);
           if (this._dres) {
-            const res = JSON.parse(msg);
-            msg = res.description;
-            if (msg.indexOf('incorrect') > -1) {
-              return [msg, 'snackbar-error']
-            }
-            if (res.status == false) {
-              return [msg, 'snackbar-warning']
-            }
-            if (res.status == true) {
-              return [msg, 'snackbar-success']
+            try {
+              const res = JSON.parse(msg);
+              msg = res.description;
+              if (msg.indexOf('incorrect') > -1) {
+                return [msg, 'snackbar-error']
+              }
+              if (res.status == false) {
+                return [msg, 'snackbar-warning']
+              }
+              if (res.status == true) {
+                return [msg, 'snackbar-success']
+              }
+            } catch(e) {
+              /* We have to catch invalid json responses. */
+              return [msg, 'snackbar-error'];
             }
           }
           if (msg.indexOf('Correct') > -1) {


### PR DESCRIPTION
Til now, the whole vbs submission service crashed as soon as a non HTTP 200 was received. This was due to the fact, that we tried to parse our logging message `Failed to submit segment to VBS due to a HTTP error` as JSON which is invalid.


![IMAGE 2020-06-07 14:29:04](https://user-images.githubusercontent.com/9994218/83968690-3d63ce80-a8cb-11ea-89cc-e748614c55a8.jpg)

Now we just print this text to the console but forward the received JSON instead, so we can show the error received to the user via snackbar.
![IMAGE 2020-06-07 14:29:51](https://user-images.githubusercontent.com/9994218/83968703-59677000-a8cb-11ea-8ae1-2e6dda89454e.jpg)


Furthermore, should we receive an invalid JSON as HTTP 200, we now don't crash as well.

To conclude, this issue was quite major as nothing worked after getting such a response. We could not even send further requests, so the whole UI was sort of broken.