### PR TITLE
http_secure config flag fix

### DIFF
--- a/src/app/shared/model/config/config.model.ts
+++ b/src/app/shared/model/config/config.model.ts
@@ -177,7 +177,7 @@ export class Config {
    * Full URL to HTTP/RESTful endpoint for Vitrivr NG.
    */
   get endpoint_http(): string {
-    const scheme = this._config.api.ws_secure ? 'https://' : 'http://';
+    const scheme = this._config.api.http_secure ? 'https://' : 'http://';
     if (this._config.api.host && this._config.api.port) {
       return scheme + this._config.api.host + ':' + this._config.api.port + '/' + Config.CONTEXT + '/' + Config.VERSION + '/';
     } else {


### PR DESCRIPTION
Fixes #40 the ws_secure flag being used instead of http_secure flag to determine whether to use TLS for http (Issue #40).
