### PR TITLE
Connection Status Notifications

### DIFF
--- a/src/app/core/api/web-socket-factory.service.ts
+++ b/src/app/core/api/web-socket-factory.service.ts
@@ -7,6 +7,7 @@ import {filter} from 'rxjs/operators';
 import {Config} from '../../shared/model/config/config.model';
 import {webSocket} from 'rxjs/webSocket';
 import {AppConfig} from '../../app.config';
+import {MatSnackBar} from '@angular/material/snack-bar';
 
 /**
  * This class exposes an observable that generates WebSocketWrapper classes whenever the connection configuration changes. Since only one WebSocketWrapper can be active
@@ -19,7 +20,7 @@ export class WebSocketFactoryService extends BehaviorSubject<WebSocketSubject<Me
   private _config: Config;
 
   /** Default constructor. */
-  constructor(@Inject(AppConfig) private _configService: AppConfig) {
+  constructor(@Inject(AppConfig) private _configService: AppConfig, private _snackbar: MatSnackBar) {
     super(null);
     this._configService.configAsObservable.pipe(
       filter(c => c.endpoint_ws != null),
@@ -28,8 +29,12 @@ export class WebSocketFactoryService extends BehaviorSubject<WebSocketSubject<Me
 
   /**
    * Reconnects the WebSocket using the current settings. If the active WebSocket instance is connected, that connection is dropped.
+   * @param snackbar if the reconnect snackbar shall be shown
    */
-  public reconnect() {
+  public reconnect(snackbar = true) {
+    if (snackbar) {
+      this._snackbar.open('Reconnecting to Cineast', 'Dismiss', {duration: 2000})
+    }
     /* If there is an active WebSocketSubject then disconnect it. */
     if (this.getValue() != null) {
       console.log('disconnecting to reconnect');
@@ -81,6 +86,6 @@ export class WebSocketFactoryService extends BehaviorSubject<WebSocketSubject<Me
     this._config = c;
 
     /* Reconnect. */
-    this.reconnect()
+    this.reconnect(false)
   }
 }

--- a/src/app/core/basics/basic.module.ts
+++ b/src/app/core/basics/basic.module.ts
@@ -6,10 +6,13 @@ import {PingService} from './ping.service';
 import {DatabaseService} from './database.service';
 import {KeyboardService} from './keyboard.service';
 import {NotificationService} from './notification.service';
+import {NoConnectDialogComponent} from './no-connect-dialog';
+import {MatDialogModule} from '@angular/material/dialog';
+import {MatButtonModule} from '@angular/material/button';
 
 @NgModule({
-  imports: [HttpClientModule],
-  declarations: [],
+  imports: [HttpClientModule, MatDialogModule, MatButtonModule],
+  declarations: [NoConnectDialogComponent],
   providers: [ResolverService, EventBusService, PingService, DatabaseService, KeyboardService, NotificationService]
 })
 

--- a/src/app/core/basics/no-connect-dialog.html
+++ b/src/app/core/basics/no-connect-dialog.html
@@ -1,0 +1,10 @@
+<h2 mat-dialog-title>Could not connect to Cineast</h2>
+
+<mat-dialog-content class="mat-typography">
+    <p>Could not connect to Cineast. Please check the URL in your config and the status of your Cineast instance.</p>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+    <button mat-button mat-dialog-close>Ignore</button>
+    <button mat-button [mat-dialog-close]="true">Reconnect</button>
+</mat-dialog-actions>

--- a/src/app/core/basics/no-connect-dialog.ts
+++ b/src/app/core/basics/no-connect-dialog.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-no-connect-dialog',
+  templateUrl: 'no-connect-dialog.html',
+})
+export class NoConnectDialogComponent {
+}

--- a/src/app/core/basics/ping.service.ts
+++ b/src/app/core/basics/ping.service.ts
@@ -1,19 +1,23 @@
 import {Inject, Injectable} from '@angular/core';
 import {BehaviorSubject, timer} from 'rxjs';
 import {WebSocketFactoryService} from '../api/web-socket-factory.service';
-import {filter, flatMap} from 'rxjs/operators';
+import {filter, flatMap, skip} from 'rxjs/operators';
 import {Message} from '../../shared/model/messages/interfaces/message.interface';
 import {ApiStatus} from '../../shared/model/internal/api-status.model';
 import {Ping} from '../../shared/model/messages/interfaces/responses/ping.interface';
 import {WebSocketSubject} from 'rxjs/webSocket';
 import {AppConfig} from '../../app.config';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {QueryService} from '../queries/query.service';
+import {MatDialog, MatDialogRef} from '@angular/material/dialog';
+import {NoConnectDialogComponent} from './no-connect-dialog';
 
 /**
  * This is one of the only classes which does not fully use the openapi-services. This is due to the fact that it exposes / measures different things than the status endpoint in cineast
  */
 @Injectable()
 export class PingService extends BehaviorSubject<ApiStatus> {
-  /** Timestamp of the last PING packet. */
+  /** Timestamp when last PING packet was sent to Cineast. */
   private _last = 0;
 
   /** Number of packets in transit. Reset after every response. */
@@ -22,13 +26,15 @@ export class PingService extends BehaviorSubject<ApiStatus> {
   /** The WebSocketWrapper currently used by QueryService to process and issue queries. */
   private _socket: WebSocketSubject<Message>;
 
-  /**
-   * Default constructor.
-   *
-   * @param _factory Reference to the WebSocketFactoryService. Gets injected by DI.
-   * @param _config
-   */
-  constructor(@Inject(WebSocketFactoryService) _factory: WebSocketFactoryService, @Inject(AppConfig) _config: AppConfig) {
+  /** Current connection status */
+  private _currentStatus = '';
+  private _dialogRef: MatDialogRef<NoConnectDialogComponent>;
+
+  constructor(@Inject(WebSocketFactoryService) private _factory: WebSocketFactoryService,
+              @Inject(AppConfig) _config: AppConfig,
+              private _snackBar: MatSnackBar,
+              private _queryService: QueryService,
+              private _dialog: MatDialog) {
     super(new ApiStatus(Date.now(), 'DISCONNECTED', Number.MAX_VALUE));
     _factory.asObservable()
       .pipe(filter(ws => ws != null))
@@ -38,6 +44,27 @@ export class PingService extends BehaviorSubject<ApiStatus> {
           filter(msg => ['PING'].indexOf(msg.messageType) > -1)
         ).subscribe((msg: Message) => this.onPingResponse(<Ping>msg));
       });
+
+    /** Ignore first element since it will be the default */
+    this.pipe(skip(1)).subscribe(status => {
+      if (status.status !== this._currentStatus && status.status === 'DISCONNECTED') {
+
+        this._dialogRef = this._dialog.open(NoConnectDialogComponent);
+
+        this._dialogRef.afterClosed().subscribe(result => {
+          if (result) {
+            this._dialogRef = undefined
+            this._factory.reconnect(true)
+          }
+        });
+      }
+      if (status.status === 'OK') {
+        if (this._dialogRef) {
+          this._dialogRef.close(false)
+        }
+      }
+      this._currentStatus = status.status
+    });
 
     /* Subscribes to changes in the configuration file and dispatches the ping timer. */
     _config.configAsObservable.pipe(flatMap(c => timer(0, c.get<number>('api.ping_interval')))).subscribe(() => this.onTimer())
@@ -55,6 +82,11 @@ export class PingService extends BehaviorSubject<ApiStatus> {
       if (this._transit > 1) {
         this.next(new ApiStatus(Date.now(), 'DISCONNECTED', Number.MAX_VALUE));
         this._transit = 0;
+        /** If a query is particularly long-running, it might look like a disconnect. In that case, we do not want to reset the WS-connection
+         * Additionally, if the user is currently deciding on what to do about reconnecting, do not attempt reconnecting. */
+        if (!this._queryService.running && !this._dialogRef) {
+          this._factory.reconnect(false)
+        }
       }
     }
   }

--- a/src/app/shared/model/config/config.model.ts
+++ b/src/app/shared/model/config/config.model.ts
@@ -23,7 +23,7 @@ export class Config {
       port: 4567, /* Port for the API. */
       http_secure: false, /* Whether or not TLS should be used for HTTP connection. */
       ws_secure: false, /* Whether or not TLS should be used for WebSocket connection. */
-      ping_interval: 10000 /* Default ping interval in milliseconds. */
+      ping_interval: 5000 /* Default ping interval in milliseconds. */
     },
     resources: {
       host_thumbnails: window.location.protocol + '//' + window.location.hostname + '/vitrivr/thumbnails',

--- a/src/app/toolbar/ping.component.ts
+++ b/src/app/toolbar/ping.component.ts
@@ -74,7 +74,7 @@ export class PingComponent {
    * Tries to re-connect to the Cineast service.
    */
   public reconnectCineast() {
-    this._factory.reconnect();
+    this._factory.reconnect(true);
   }
 
   /**


### PR DESCRIPTION
There is a popup if vitrivr-ng cannot connect to Cineast. This popup can either be dismissed, then no reconnection attempts will be made, or vitrivr-ng can try connecting again.

Additionally, if cineast is restarted, vitrivr-ng continously tries reconnecting