### PR TITLE
update the location of resources in config.json

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -3,8 +3,8 @@
     "host": "default"
   },
   "resources": {
-    "host_thumbnails": "http://10.34.58.178/V3C1/V3C1jpg/:o/:s.jpg",
-    "host_objects": "http://10.34.58.178/V3C1/video/:o.mp4"
+    "host_thumbnails": "http://localhost:4567/thumbnails/:s",
+    "host_objects": "http://localhost:4567/objects/:o"
   },
   "competition": {
     "teamid": 9,


### PR DESCRIPTION
# Description

The thumbnails of result pictures are blank after searching

Fixes # (issue)
I solved this issue by [this post](https://github.com/vitrivr/vitrivr-ng/issues/43). The problem is caused by the inaccessible location of resources (http://10.34.58.178/V3C1/). The change to local default cineast server might be better for most clone-and-run people.

# Are there any open issues?
No

# How Has This Been Tested?

With Cottontail DB and Cineast running at background, any search at vitrivr-ng UI will display thumbnails normally.

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (wiki, README, Website)
- [ ] I have updated the pre-built binary on the release page (for major changes)
