### PR TITLE
Dev

### DIFF
--- a/src/app/core/lookup/distinct-element-lookup.service.ts
+++ b/src/app/core/lookup/distinct-element-lookup.service.ts
@@ -1,7 +1,6 @@
 import {Inject, Injectable} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, BehaviorSubject} from 'rxjs';
 import {first} from 'rxjs/operators';
-import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import {MiscService} from '../../../../openapi/cineast';
 
 /**

--- a/src/app/core/vbs/vbs-interaction-log.model.ts
+++ b/src/app/core/vbs/vbs-interaction-log.model.ts
@@ -1,4 +1,4 @@
-import {Observable} from 'rxjs';
+import {from, Observable, of} from 'rxjs';
 import {InteractionEventType} from '../../shared/model/events/interaction-event-type.model';
 import {InteractionEvent} from '../../shared/model/events/interaction-event.model';
 import {WeightedFeatureCategory} from '../../shared/model/results/weighted-feature-category.model';
@@ -29,9 +29,9 @@ export class VbsInteractionLog implements VbsSubmission {
       flatMap(e => {
         if (e.components.length > 1) {
           const composit = e.components.map(c => VbsInteractionLog.mapAtomicEvent(c, e.timestamp));
-          return Observable.from(composit);
+          return from(composit);
         } else {
-          return Observable.of(<VbsInteraction>(VbsInteractionLog.mapAtomicEvent(e.components[0], e.timestamp)));
+          return of(VbsInteractionLog.mapAtomicEvent(e.components[0], e.timestamp));
         }
       }),
       catchError((e, o) => {

--- a/src/app/evaluation/evaluation-selection.component.ts
+++ b/src/app/evaluation/evaluation-selection.component.ts
@@ -52,7 +52,7 @@ export class EvaluationSelectionComponent {
    * Invoked whenever the 'CONTINUE EVALUATION' button is clicked.
    */
   public onContinueClick() {
-    if (!this.enteredId || this.enteredId.length == 0) {
+    if (!this.enteredId || this.enteredId.length === 0) {
       this.snackBar.open('Please enter a valid evaluation ID.', null, {duration: 3000});
       return;
     }

--- a/src/app/evaluation/evaluation.component.ts
+++ b/src/app/evaluation/evaluation.component.ts
@@ -110,7 +110,7 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
    * Invoked whenever the 'Complete Scenario' button is clicked.
    */
   public onEvaluationCompleteButtonClick() {
-    if (this.canBeCompleted() && this._evaluationset.current.state == EvaluationState.RankingResults) {
+    if (this.canBeCompleted() && this._evaluationset.current.state === EvaluationState.RankingResults) {
       this._evaluationset.current.complete();
       if (!this._evaluationset.next()) {
         this._snackBar.open('Evaluation completed. Thank you for participating!', null, {duration: Config.SNACKBAR_DURATION});
@@ -128,7 +128,7 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
   public onResultsAcceptButtonClick() {
     if (this.canBeAccepted()) {
       this._dataSource.pipe(first()).subscribe(m => {
-        if (this._evaluationset.current.accept(this._queryService.results.features, m) == EvaluationState.RankingResults) {
+        if (this._evaluationset.current.accept(this._queryService.results.features, m) === EvaluationState.RankingResults) {
           this.saveEvaluation();
           this._snackBar.open('Results accepted. Now please rate the relevance of the top ' + this._evaluationset.current.k + ' results.', null, {duration: Config.SNACKBAR_DURATION});
         }
@@ -277,10 +277,10 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
    * Used to make UI related decisions.
    */
   public canBeStarted(): boolean {
-    if (this._evaluationset == null) {
+    if (this._evaluationset === null) {
       return false;
     }
-    return this._evaluationset.current.state == EvaluationState.NotStarted || this._evaluationset.current.state == EvaluationState.Aborted
+    return this._evaluationset.current.state === EvaluationState.NotStarted || this._evaluationset.current.state === EvaluationState.Aborted
   }
 
   /**
@@ -290,10 +290,10 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
    * Used to make UI related decisions.
    */
   public canBeAborted(): boolean {
-    if (this._evaluationset == null) {
+    if (this._evaluationset === null) {
       return false;
     }
-    return this._evaluationset.current.state != EvaluationState.NotStarted && this._evaluationset.current.state != EvaluationState.Aborted;
+    return this._evaluationset.current.state !== EvaluationState.NotStarted && this._evaluationset.current.state !== EvaluationState.Aborted;
   }
 
   /**
@@ -301,10 +301,10 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
    * @return {boolean}
    */
   public canBeCompleted(): boolean {
-    if (this._evaluationset == null) {
+    if (this._evaluationset === null) {
       return false;
     }
-    return this._evaluationset.current.state == EvaluationState.RankingResults
+    return this._evaluationset.current.state === EvaluationState.RankingResults
 
   }
 
@@ -315,10 +315,10 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
    * Used to make UI related decisions.
    */
   public canBeAccepted(): boolean {
-    if (this._evaluationset == null) {
+    if (this._evaluationset === null) {
       return false;
     }
-    return this._evaluationset.current.state == EvaluationState.RunningQueries;
+    return this._evaluationset.current.state === EvaluationState.RunningQueries;
   }
 
   /**
@@ -327,10 +327,10 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
    * Used to make UI related decisions.
    */
   public canBeRated(): boolean {
-    if (this._evaluationset == null) {
+    if (this._evaluationset === null) {
       return false;
     }
-    return this._evaluationset.current.state == EvaluationState.RankingResults;
+    return this._evaluationset.current.state === EvaluationState.RankingResults;
   }
 
   /**
@@ -362,7 +362,7 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
    * @param mediaobject MediaObject that should be checked.
    */
   public objectCanBeRated(mediaobject: MediaObjectScoreContainer): Observable<boolean> {
-    if (this.canBeRated() == false) {
+    if (this.canBeRated() === false) {
       of(false);
     }
     return this.dataSource.pipe(
@@ -378,7 +378,7 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
    * @param mediaobject MediaObject that should be checked.
    */
   public objectHasBeenRated(mediaobject: MediaObjectScoreContainer): Observable<boolean> {
-    if (this.canBeRated() == false) {
+    if (this.canBeRated() === false) {
       of(false);
     }
     return this.dataSource.pipe(
@@ -414,7 +414,7 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
     }
 
     /* Add evaluation event. */
-    if (event && this._evaluationset && this._evaluationset.current.state == EvaluationState.RunningQueries) {
+    if (event && this._evaluationset && this._evaluationset.current.state === EvaluationState.RunningQueries) {
       this._evaluationset.current.addEvent(event);
       this.saveEvaluation();
     }
@@ -492,7 +492,7 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
       first(),
       flatMap((evaluation) => {
         return zip(of(evaluation), this._evaluation.loadEvaluationTemplate(evaluation.template), (evaluation, template) => {
-          if (template != null) {
+          if (template !== null) {
             this._evaluationset = evaluation;
             this._template = template;
           } else {
@@ -515,7 +515,7 @@ export class EvaluationComponent extends GalleryComponent implements OnInit, OnD
     return this._evaluation.loadEvaluationTemplate(url).pipe(
       first(),
       map((template) => {
-        if (template != null) {
+        if (template !== null) {
           this._template = template;
           this._evaluationset = EvaluationSet.fromTemplate(participant, template, name);
         } else {

--- a/src/app/query/containers/audio/audio-recorder-dialog.component.ts
+++ b/src/app/query/containers/audio/audio-recorder-dialog.component.ts
@@ -17,7 +17,7 @@ import {timestamp} from 'rxjs/operators';
   ]
 })
 export class AudioRecorderDialogComponent implements OnInit, OnDestroy {
-;
+
   /** Hidden input for image upload. */
   @ViewChild('audioloader')
   private audioloader: any;
@@ -71,20 +71,20 @@ export class AudioRecorderDialogComponent implements OnInit, OnDestroy {
     }
     this._data = null;
     this._timer = timer(0, 500).pipe(timestamp()).subscribe((x) => {
-      if (this._recorder.isPlaying() && this.status != 'Playing') {
+      if (this._recorder.isPlaying() && this.status !== 'Playing') {
         this.start = x.timestamp;
         this.status = 'Playing';
-      } else if (this._recorder.isRecording() && this.status != 'Recording') {
+      } else if (this._recorder.isRecording() && this.status !== 'Recording') {
         this.start = x.timestamp;
         this.status = 'Recording';
-      } else if (!this._recorder.isPlaying() && !this._recorder.isRecording() && this.status != 'Idle') {
+      } else if (!this._recorder.isPlaying() && !this._recorder.isRecording() && this.status !== 'Idle') {
         this.start = 0;
         this.status = 'Idle';
-      } else if (this.status == 'Recording') {
+      } else if (this.status === 'Recording') {
         this._statustext = 'Recording: ' + TimeFormatterUtil.toTimer(x.timestamp - this.start);
-      } else if (this.status == 'Playing') {
+      } else if (this.status === 'Playing') {
         this._statustext = 'Playing: ' + TimeFormatterUtil.toTimer(x.timestamp - this.start) + ' / ' + TimeFormatterUtil.toTimer(this._recorder.duration() * 1000);
-      } else if (this.status == 'Idle') {
+      } else if (this.status === 'Idle') {
         if (this._recorder.length() > 0) {
           this._statustext = 'Idle (Audio available)';
         } else {

--- a/src/app/query/containers/bool/bool-query-term.component.ts
+++ b/src/app/query/containers/bool/bool-query-term.component.ts
@@ -1,7 +1,7 @@
 import {Component, ComponentFactoryResolver, Injectable, Input, OnInit} from '@angular/core';
 import {BoolQueryTerm} from '../../../shared/model/queries/bool-query-term.model';
 import {BoolAttribute, ValueType} from './bool-attribute';
-import {BehaviorSubject} from 'rxjs/Rx';
+import {BehaviorSubject} from 'rxjs';
 import {BoolTerm} from './individual/bool-term';
 import {DistinctElementLookupService} from '../../../core/lookup/distinct-element-lookup.service';
 import {first, map} from 'rxjs/operators';

--- a/src/app/query/containers/bool/individual/bool-term.component.ts
+++ b/src/app/query/containers/bool/individual/bool-term.component.ts
@@ -1,7 +1,7 @@
 import {Component, Injectable, Input, OnInit} from '@angular/core';
 import {BoolQueryTerm} from '../../../../shared/model/queries/bool-query-term.model';
 import {BoolAttribute, BoolOperator, ValueType} from '../bool-attribute';
-import {BehaviorSubject, Observable} from 'rxjs/Rx';
+import {BehaviorSubject, Observable} from 'rxjs';
 import {BoolTerm} from './bool-term';
 
 @Component({
@@ -49,7 +49,7 @@ export class BoolTermComponent implements OnInit {
    * By default, the operator is set to equals since that is supported by all boolean types
    */
   get operatorValue(): BoolOperator {
-    if (this.currentOperator == null) {
+    if (this.currentOperator === null) {
       return BoolOperator.EQ;
     }
     return this.currentOperator;
@@ -125,7 +125,7 @@ export class BoolTermComponent implements OnInit {
 
 
   attributeIsText(attr: BoolAttribute) {
-    return attr.valueType.valueOf() == 2 || attr.valueType.valueOf() == 3;
+    return attr.valueType.valueOf() === 2 || attr.valueType.valueOf() === 3;
   }
 
   /**
@@ -154,14 +154,14 @@ export class BoolTermComponent implements OnInit {
       case ValueType.DATE:
       case ValueType.NUMERIC:
       case ValueType.TEXT:
-        if (this.term.values && this.term.values != []) {
+        if (this.term.values && this.term.values !== []) {
           this.inputValue = this.term.values[0];
         } else {
           this.inputValue = '';
         }
         break;
       case ValueType.RANGE:
-        if (this.term.values && this.term.values != []) {
+        if (this.term.values && this.term.values !== []) {
           const min = this.term.values[0];
           const max = this.term.values[1];
           this.minValue = min;
@@ -172,13 +172,13 @@ export class BoolTermComponent implements OnInit {
         }
         break;
     }
-    if (this.currentAttributeObservable.getValue().valueType == ValueType.RANGE) {
+    if (this.currentAttributeObservable.getValue().valueType === ValueType.RANGE) {
       this.updateRangeValue();
     }
     this.updateTerm();
   }
 
   isOption(): boolean {
-    return this.attribute.valueType.valueOf() == 0 || this.attribute.valueType.valueOf() == 5;
+    return this.attribute.valueType.valueOf() === 0 || this.attribute.valueType.valueOf() === 5;
   }
 }

--- a/src/app/query/containers/semantic/semantic-sketch-dialog.component.ts
+++ b/src/app/query/containers/semantic/semantic-sketch-dialog.component.ts
@@ -62,9 +62,9 @@ export class SemanticSketchDialogComponent implements OnInit, AfterViewInit {
         return array[0].sort((a, b) => {
           const ia = array[1].indexOf(a);
           const ib = array[1].indexOf(b);
-          if (ia == -1 && ib != -1) {
+          if (ia === -1 && ib !== -1) {
             return 1;
-          } else if (ia != -1 && ib == -1) {
+          } else if (ia !== -1 && ib === -1) {
             return -1;
           } else if (a.name < b.name) {
             return -1
@@ -131,7 +131,7 @@ export class SemanticSketchDialogComponent implements OnInit, AfterViewInit {
     this._selected = selection;
     this._sketchpad.setActiveColor(selection.color);
     const arr = this._used.getValue().concat().slice();
-    if (arr.indexOf(selection) == -1) {
+    if (arr.indexOf(selection) === -1) {
       arr.push(selection);
       this._used.next(arr);
     }
@@ -169,7 +169,7 @@ export class SemanticSketchDialogComponent implements OnInit, AfterViewInit {
    */
   public onOptionSelected(selected: string) {
     for (const category of this._categories) {
-      if (category.name == selected) {
+      if (category.name === selected) {
         this.onItemSelected(category);
         break;
       }

--- a/src/app/results/abstract-results-view.component.ts
+++ b/src/app/results/abstract-results-view.component.ts
@@ -20,6 +20,7 @@ import {filter} from 'rxjs/operators';
 import {FilterService} from '../core/queries/filter.service';
 
 @Directive()
+// tslint:disable-next-line:directive-class-suffix
 export abstract class AbstractResultsViewComponent<T> implements OnInit, OnDestroy {
   /** Local reference to the subscription to the QueryService. */
   protected _queryServiceSubscription;

--- a/src/app/results/abstract-segment-results-view.component.ts
+++ b/src/app/results/abstract-segment-results-view.component.ts
@@ -18,6 +18,7 @@ import {AppConfig} from '../app.config';
  * More specialized AbstractResultsView, tailored for views which display segments
  */
 @Directive()
+// tslint:disable-next-line:directive-class-suffix
 export abstract class AbstractSegmentResultsViewComponent<T> extends AbstractResultsViewComponent<T> {
 
   protected constructor(_cdr: ChangeDetectorRef,

--- a/src/app/results/gallery/gallery.component.ts
+++ b/src/app/results/gallery/gallery.component.ts
@@ -43,7 +43,9 @@ export class GalleryComponent extends AbstractResultsViewComponent<MediaObjectSc
    * @param _snackBar The MatSnackBar component used to display the SnackBar.
    * @param _resolver
    */
-  constructor(_cdr: ChangeDetectorRef, _queryService: QueryService, _filterService: FilterService, _selectionService: SelectionService, _eventBusService: EventBusService, _router: Router, _snackBar: MatSnackBar, public _resolver: ResolverService) {
+  constructor(_cdr: ChangeDetectorRef, _queryService: QueryService, _filterService: FilterService,
+              _selectionService: SelectionService, _eventBusService: EventBusService, _router: Router,
+              _snackBar: MatSnackBar, public _resolver: ResolverService) {
     super(_cdr, _queryService, _filterService, _selectionService, _eventBusService, _router, _snackBar);
   }
 
@@ -113,7 +115,7 @@ export class GalleryComponent extends AbstractResultsViewComponent<MediaObjectSc
    * @return {boolean}
    */
   public inFocus(mediaobject: MediaObjectScoreContainer) {
-    return this._focus == mediaobject;
+    return this._focus === mediaobject;
   }
 
   scrollIncrement(): number {

--- a/src/app/settings/preferences/preferences.component.ts
+++ b/src/app/settings/preferences/preferences.component.ts
@@ -224,7 +224,7 @@ export class PreferencesComponent implements AfterContentInit {
    */
   public onUseInexactIndexChanged(e: MatSlideToggleChange) {
     this._config.pipe(first()).subscribe(c => {
-      const hints = c.get<Hint[]>('query.config.hints').filter(h => ['inexact', 'exact'].indexOf(h) == -1);
+      const hints = c.get<Hint[]>('query.config.hints').filter(h => ['inexact', 'exact'].indexOf(h) === -1);
       if (e.checked === true) {
         hints.push('inexact');
       } else {

--- a/src/app/shared/components/audio/audio-recorder.component.ts
+++ b/src/app/shared/components/audio/audio-recorder.component.ts
@@ -103,10 +103,10 @@ export class AudioRecorderComponent implements OnInit, OnDestroy {
    * Starts recording of audio. The actual audio recording is done in the process() method.
    */
   public record(): void {
-    if (this.audiocontext == undefined) {
+    if (this.audiocontext === undefined) {
       return;
     }
-    if (this.stream == undefined) {
+    if (this.stream === undefined) {
       return;
     }
     if (!this.recording && !this.playing) {
@@ -122,14 +122,14 @@ export class AudioRecorderComponent implements OnInit, OnDestroy {
    * @return {boolean}
    */
   public recordingAvailable(): boolean {
-    return this.source != null;
+    return this.source !== null;
   }
 
   /**
    * Starts playback of previously recorded audio (if set).
    */
   public play(): void {
-    if (this.audiocontext == undefined) {
+    if (this.audiocontext === undefined) {
       return;
     }
     if (!this.recording && !this.playing && this.recordingBuffer) {
@@ -149,7 +149,7 @@ export class AudioRecorderComponent implements OnInit, OnDestroy {
    * Stops either playback or recording, whatever is currently running.
    */
   public stop(): void {
-    if (this.audiocontext == undefined) {
+    if (this.audiocontext === undefined) {
       return;
     }
     if (this.recording) {
@@ -253,7 +253,7 @@ export class AudioRecorderComponent implements OnInit, OnDestroy {
    * mainly depends on the browser's capabilities.
    */
   public supportsRecording() {
-    return this.audiocontext != undefined && this.stream != undefined;
+    return this.audiocontext !== undefined && this.stream !== undefined;
   }
 
   /**
@@ -402,7 +402,7 @@ export class AudioRecorderComponent implements OnInit, OnDestroy {
    * establish during recording.
    */
   private setupAudioNodes(): void {
-    if (this.audiocontext != undefined) {
+    if (this.audiocontext !== undefined) {
       this.analyser = this.audiocontext.createAnalyser();
       this.processor = this.audiocontext.createScriptProcessor();
       this.processor.onaudioprocess = (event) => this.process(event.inputBuffer);
@@ -430,14 +430,14 @@ export class AudioRecorderComponent implements OnInit, OnDestroy {
    */
   private process(input: AudioBuffer) {
     let buffer: AudioBuffer;
-    if (this.recordingBuffer == null) {
+    if (this.recordingBuffer === null) {
       buffer = this.audiocontext.createBuffer(input.numberOfChannels, input.length, input.sampleRate);
     } else {
       buffer = this.audiocontext.createBuffer(input.numberOfChannels, this.recordingBuffer.length + input.length, input.sampleRate);
     }
 
     for (let c = 0; c < input.numberOfChannels; c++) {
-      if (this.recordingBuffer != null) {
+      if (this.recordingBuffer !== null) {
         buffer.copyToChannel(this.recordingBuffer.getChannelData(c), c, 0);
         buffer.copyToChannel(input.getChannelData(c), c, this.recordingBuffer.length);
       } else {

--- a/src/app/shared/components/sketch/sketch-canvas.component.ts
+++ b/src/app/shared/components/sketch/sketch-canvas.component.ts
@@ -57,7 +57,7 @@ export class SketchCanvasComponent implements OnInit {
    * @param event
    */
   public onMousemove(event: MouseEvent) {
-    if (this.paint && event.target == this.canvas.nativeElement) {
+    if (this.paint && event.target === this.canvas.nativeElement) {
       this.current = new Point(event.offsetX, event.offsetY);
       if (this.last !== null) {
         Point.drawLine(this.context, this.last, this.current);
@@ -94,6 +94,7 @@ export class SketchCanvasComponent implements OnInit {
 
   @HostListener('window:resize', ['$event'])
   onResize(event: any) {
+    // tslint:disable-next-line:no-unused-expression
     event.target.innerWidth;
   }
 

--- a/src/app/shared/components/sketch/tracking-sketch-canvas.component.ts
+++ b/src/app/shared/components/sketch/tracking-sketch-canvas.component.ts
@@ -74,7 +74,7 @@ export class TrackingSketchCanvasComponent implements OnInit {
    * point is appended to the current line.
    */
   public onMousemove(event: MouseEvent) {
-    if (this.drawing && event.target == this.canvas.nativeElement && this._drawables.length > 0) {
+    if (this.drawing && event.target === this.canvas.nativeElement && this._drawables.length > 0) {
       const current: Drawable = this._drawables[this._drawables.length - 1];
       if (current.append(new Point(event.offsetX, event.offsetY))) {
         this.redraw();
@@ -98,6 +98,7 @@ export class TrackingSketchCanvasComponent implements OnInit {
 
   @HostListener('window:resize', ['$event'])
   public onResize(event: any) {
+    // tslint:disable-next-line:no-unused-expression
     event.target.innerWidth;
   }
 

--- a/src/app/shared/model/config/config.model.ts
+++ b/src/app/shared/model/config/config.model.ts
@@ -256,7 +256,7 @@ export class Config {
         }
       }, this._config);
 
-      if (obj[last] && typeof value == typeof obj[last]) {
+      if (obj[last] && typeof value === typeof obj[last]) {
         obj[last] = value;
         return true;
       } else {

--- a/src/app/shared/model/evaluation/evaluation-template.ts
+++ b/src/app/shared/model/evaluation/evaluation-template.ts
@@ -22,7 +22,7 @@ export class EvaluationTemplate {
    */
   public static fromJson(object: any, url: string): EvaluationTemplate {
     try {
-      if (typeof object == 'string') {
+      if (typeof object === 'string') {
         object = JSON.parse(object);
       }
       const template = new EvaluationTemplate(url, object['_name'], object['_description']);

--- a/src/app/shared/model/evaluation/evaluation.ts
+++ b/src/app/shared/model/evaluation/evaluation.ts
@@ -182,7 +182,7 @@ export class Evaluation {
    * @return New state of the Evaluation object.
    */
   public start(): EvaluationState {
-    if (this._state == EvaluationState.NotStarted || this._state == EvaluationState.Aborted) {
+    if (this._state === EvaluationState.NotStarted || this._state === EvaluationState.Aborted) {
       this._state = EvaluationState.RunningQueries;
       this._begin = new Date();
     }
@@ -196,7 +196,7 @@ export class Evaluation {
    * @return New state of the Evaluation object.
    */
   public accept(features: WeightedFeatureCategory[], results: MediaObjectScoreContainer[]): EvaluationState {
-    if (this._state == EvaluationState.RunningQueries) {
+    if (this._state === EvaluationState.RunningQueries) {
       /* Store per-category weights. */
       this._per_category_weights = {};
       features.forEach((v, i) => {
@@ -225,7 +225,7 @@ export class Evaluation {
    * @return New state of the Evaluation object.
    */
   public complete(): EvaluationState {
-    if (this._state == EvaluationState.RankingResults) {
+    if (this._state === EvaluationState.RankingResults) {
       this._state = EvaluationState.Finished;
       this._end = new Date();
     }
@@ -238,7 +238,7 @@ export class Evaluation {
    * @return New state of the Evaluation object.
    */
   public abort(): EvaluationState {
-    if (this._state != EvaluationState.Aborted && this._state != EvaluationState.NotStarted) {
+    if (this._state !== EvaluationState.Aborted && this._state !== EvaluationState.NotStarted) {
       this._state = EvaluationState.Aborted;
       this._begin = null;
       this._end = null;
@@ -254,7 +254,7 @@ export class Evaluation {
    * @param event EvaluationEvent to be added.
    */
   public addEvent(event: EvaluationEvent) {
-    if (this.state == EvaluationState.RunningQueries) {
+    if (this.state === EvaluationState.RunningQueries) {
       this._events.push(event);
     }
   }
@@ -264,9 +264,9 @@ export class Evaluation {
    * @returns {string}
    */
   public elapsedTime(): string {
-    if (this.state == EvaluationState.NotStarted) {
+    if (this.state === EvaluationState.NotStarted) {
       return '00:00:00';
-    } else if (this.state == EvaluationState.Finished || this.state == EvaluationState.Aborted) {
+    } else if (this.state === EvaluationState.Finished || this.state === EvaluationState.Aborted) {
       return TimeFormatterUtil.toTimer(this._end.getTime() - this._begin.getTime())
     } else {
       return TimeFormatterUtil.toTimer(new Date().getTime() - this._begin.getTime())
@@ -279,7 +279,7 @@ export class Evaluation {
    * @param rating
    */
   public rate(index: number, rating: number) {
-    if (this.state != EvaluationState.RankingResults) {
+    if (this.state !== EvaluationState.RankingResults) {
       return;
     }
     if (index >= this._ratings.length) {

--- a/src/app/shared/model/queries/abstract-query-term.model.ts
+++ b/src/app/shared/model/queries/abstract-query-term.model.ts
@@ -25,7 +25,7 @@ export abstract class AbstractQueryTerm implements QueryTermInterface {
    */
   public pushCategory(category: string) {
     const index: number = this.categories.indexOf(category);
-    if (index == -1) {
+    if (index === -1) {
       this.categories.push(category);
     }
   }

--- a/src/app/shared/model/queries/interfaces/query-container.interface.ts
+++ b/src/app/shared/model/queries/interfaces/query-container.interface.ts
@@ -3,7 +3,9 @@ import {QueryStage} from '../query-stage.model';
 import {QueryTerm} from '../../../../../../openapi/cineast/model/queryTerm';
 
 /**
- * The Query Container corresponds to one StagedSimilarityQuery. It has multiple stages, which can each contain multiple queryterms. Each type of queryterm can only occur once in a query container interface.
+ * The Query Container corresponds to one StagedSimilarityQuery.
+ * It has multiple stages, which can each contain multiple queryterms.
+ * Each type of queryterm can only occur once in a query container interface.
  */
 export interface QueryContainerInterface {
 

--- a/src/app/shared/pipes/containers/container-pipes.module.ts
+++ b/src/app/shared/pipes/containers/container-pipes.module.ts
@@ -13,7 +13,9 @@ import {OrderByPipe} from './order-by.pipe';
 
 @NgModule({
   imports: [],
+  // tslint:disable-next-line:max-line-length
   declarations: [OrderBySegmentPipe, FlattenPathsPipe, OrderObjectByBestPathScorePipe, OrderByScorePipe, FilterPipe, LimitPipe, ArrayObjectSortPipe, SetStringSortPipe, LimitObjectsPipe, OrderBySegmentIdPipe, OrderByPipe],
+  // tslint:disable-next-line:max-line-length
   exports: [OrderBySegmentPipe, FlattenPathsPipe, OrderObjectByBestPathScorePipe, OrderByScorePipe, FilterPipe, LimitPipe, ArrayObjectSortPipe, SetStringSortPipe, LimitObjectsPipe, OrderBySegmentIdPipe, OrderByPipe]
 })
 export class ContainerPipesModule {

--- a/src/app/shared/util/wave-audio.util.ts
+++ b/src/app/shared/util/wave-audio.util.ts
@@ -39,7 +39,7 @@ export class WaveAudioUtil {
    */
   public static resample(audio: AudioBuffer, channels: number, sampleRate: number) {
     /* If no resampling is necessary, just return a promise. */
-    if (audio.sampleRate == sampleRate && audio.numberOfChannels == channels) {
+    if (audio.sampleRate === sampleRate && audio.numberOfChannels === channels) {
       return Promise.resolve(audio);
     }
 

--- a/src/config.json
+++ b/src/config.json
@@ -3,8 +3,8 @@
     "host": "default"
   },
   "resources": {
-    "host_thumbnails": "http://localhost:4567/thumbnails/:s",
-    "host_objects": "http://localhost:4567/objects/:o"
+    "host_thumbnails": "http://localhost:4567/thumbnails/:o/:s:x",
+    "host_objects": "http://localhost:4567/objects/:n"
   },
   "competition": {
     "teamid": 9,


### PR DESCRIPTION
While testing cottontail schema migration, I noticed that the boolean dropdowns are broken on prod builds of vitrivr-ng. This PR fixes that and adds ts-linting for rxjs to the codebase. It also includes long overdue tslint fixes where tslint always complained about the usage of `==`. It also switches to more sensible default-values for thumbnail / object-locations.
