### PR TITLE
Configurable tag prioritisation

### DIFF
--- a/src/app/query/containers/tag/tag-query-term.component.html
+++ b/src/app/query/containers/tag/tag-query-term.component.html
@@ -1,41 +1,41 @@
 <div [style.padding-left]="'10px'" [style.text-align]="'left'">
-    <mat-form-field class="textinput">
-        <input [formControl]="_field.formControl" [matAutocomplete]="auto" aria-label="Enter a tag"
-               matInput
-               placeholder="Enter a tag">
-        <mat-autocomplete [panelWidth]="450" #auto="matAutocomplete" (optionSelected)="onTagSelected($event)">
-            <mat-option *ngFor="let tag of _field.filteredTags | async" [value]="tag">
-                <small>{{tag.name}}: {{tag.description}}</small>
-            </mat-option>
-        </mat-autocomplete>
-    </mat-form-field>
-    <mat-chip-list>
-        <mat-chip class="dropdown" (removed)="removeTag(tag)" *ngFor="let tag of _tags" [removable]="true"
-                  [selectable]="true"
-                  id="{{tag.id}}">
-            {{tag.name}}&nbsp;<small>({{tag.id}})</small>
-            <mat-icon matChipRemove matTooltip="Remove tag from list">cancel</mat-icon>
-            <button mat-icon-button [matMenuTriggerFor]="menu">
-                <mat-icon *ngIf="tag.priority == null">menu</mat-icon>
-                <mat-icon *ngIf="tag.priority == 'REQUIRE'" class="require-icon">warning_amber</mat-icon>
-                <mat-icon *ngIf="tag.priority == 'REQUEST'" class="request-icon">check_circle_outline</mat-icon>
-                <mat-icon *ngIf="tag.priority == 'EXCLUDE'" class="exclude-icon">not_interested</mat-icon>
-            </button>
-            <mat-menu #menu="matMenu" [overlapTrigger]="false">
-            <span>
-                <mat-button-toggle-group>
-                    <mat-button-toggle (change)="onPriorityChange('REQUIRE', tag)" value="REQUIRE" class="require-icon">
+  <mat-form-field class="textinput">
+    <input [formControl]="_field.formControl" [matAutocomplete]="auto" aria-label="Enter a tag"
+           matInput
+           placeholder="Enter a tag">
+    <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onTagSelected($event)" [panelWidth]="450">
+      <mat-option *ngFor="let tag of _field.filteredTags | async" [value]="tag">
+        <small>{{tag.name}}: {{tag.description}}</small>
+      </mat-option>
+    </mat-autocomplete>
+  </mat-form-field>
+  <mat-chip-list>
+    <mat-chip (removed)="removeTag(tag)" *ngFor="let tag of _tags" [removable]="true" [selectable]="true"
+              class="dropdown"
+              id="{{tag.id}}">
+      {{tag.name}}&nbsp;<small>({{tag.id}})</small>
+      <mat-icon matChipRemove matTooltip="Remove tag from list">cancel</mat-icon>
+      <span *ngIf="config.config.get('query.enableTagPrioritisation')">
+        <button [matMenuTriggerFor]="menu" mat-icon-button>
+          <mat-icon *ngIf="tag.priority == null">menu</mat-icon>
+          <mat-icon *ngIf="tag.priority == 'REQUIRE'" class="require-icon">warning_amber</mat-icon>
+          <mat-icon *ngIf="tag.priority == 'REQUEST'" class="request-icon">check_circle_outline</mat-icon>
+          <mat-icon *ngIf="tag.priority == 'EXCLUDE'" class="exclude-icon">not_interested</mat-icon>
+        </button>
+      <mat-menu #menu="matMenu" [overlapTrigger]="false">
+                <mat-button-toggle-group mat-menu-item>
+                    <mat-button-toggle (change)="onPriorityChange('REQUIRE', tag)" class="require-icon" value="REQUIRE">
                         <mat-icon>warning_amber</mat-icon>
                     </mat-button-toggle>
-                    <mat-button-toggle (change)="onPriorityChange('REQUEST', tag)" value="REQUEST" class="request-icon">
+                    <mat-button-toggle (change)="onPriorityChange('REQUEST', tag)" class="request-icon" value="REQUEST">
                         <mat-icon>check_circle_outline</mat-icon>
                     </mat-button-toggle>
-                    <mat-button-toggle (change)="onPriorityChange('EXCLUDE', tag)" value="EXCLUDE" class="exclude-icon">
+                    <mat-button-toggle (change)="onPriorityChange('EXCLUDE', tag)" class="exclude-icon" value="EXCLUDE">
                         <mat-icon>not_interested</mat-icon>
                     </mat-button-toggle>
                 </mat-button-toggle-group>
-            </span>
-            </mat-menu>
-        </mat-chip>
-    </mat-chip-list>
+      </mat-menu>
+        </span>
+    </mat-chip>
+  </mat-chip-list>
 </div>

--- a/src/app/query/containers/tag/tag-query-term.component.ts
+++ b/src/app/query/containers/tag/tag-query-term.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnInit, ViewChild} from '@angular/core';
 import {TagQueryTerm} from '../../../shared/model/queries/tag-query-term.model';
 import {FormControl} from '@angular/forms';
 import {EMPTY, Observable} from 'rxjs';
@@ -7,6 +7,8 @@ import {MatAutocompleteSelectedEvent} from '@angular/material/autocomplete';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {Tag, TagService} from '../../../../../openapi/cineast';
 import PriorityEnum = Tag.PriorityEnum;
+import {AppConfig} from '../../../app.config';
+import {MatMenu} from '@angular/material/menu';
 
 @Component({
   selector: 'app-qt-tag',
@@ -24,7 +26,9 @@ export class TagQueryTermComponent implements OnInit {
   /** List of tag fields currently displayed. */
   _tags: Tag[] = [];
 
-  constructor(_tagService: TagService, private _matsnackbar: MatSnackBar) {
+  @ViewChild(MatMenu, {static: true}) menu: MatMenu;
+
+  constructor(_tagService: TagService, private _matsnackbar: MatSnackBar, public config: AppConfig) {
     this._field = new FieldGroup(_tagService);
   }
 

--- a/src/app/shared/model/config/config.model.ts
+++ b/src/app/shared/model/config/config.model.ts
@@ -98,7 +98,8 @@ export class Config {
         categories: []
       },
       boolean: [],
-      temporal_mode: 'TEMPORAL_DISTANCE'
+      temporal_mode: 'TEMPORAL_DISTANCE',
+      enableTagPrioritisation: false
     },
     refinement: {
       filters: [

--- a/src/config.json
+++ b/src/config.json
@@ -78,7 +78,8 @@
         "option"
       ]
     ],
-    "staged": true
+    "staged": true,
+    "enableTagPrioritisation": true
   },
   "refinement": {
     "filters": [


### PR DESCRIPTION
# Description

Introduces a config flag to toggle the tag prioritisation menu in query formulation.
By default, this is turn off.

Fixes #85 

# How Has This Been Tested?

Playtesting locally

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
