### PR TITLE
Adjusted node versions for macOS aarch64 support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 plugins {
-  id "com.github.node-gradle.node" version "3.0.1"
+  id "com.github.node-gradle.node" version "3.2.1"
 }
 
 node {
   download = true
+  version = "17.5.0"
 }
 
 task buildAngularApp(type: NpxTask) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "leaflet-geosearch": "3.6.0",
         "ngx-color-picker": "11.0.0",
         "ngx-infinite-scroll": "10.0.1",
-        "node": "^17.1.0",
+        "node": "^17.4.0",
         "npm": "^8.1.2",
         "openseadragon": "^2.4.2",
         "rxjs": "7.4.0",
@@ -9694,9 +9694,9 @@
       }
     },
     "node_modules/node": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-17.1.0.tgz",
-      "integrity": "sha512-1gg810R7sKtFkCYMdIhOyYDCuRJZyLvP+lTX8Z9AMAiUdHPoeNu0KQN59CzBud5L/vMtFPkbsCwWOy1aTYOL8g==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-17.4.0.tgz",
+      "integrity": "sha512-/kPlbyQjDJa9NEOPmKSTmHOxgq+7wAMWNdU+8B9cXseQXTaF3xYAiYc9dCh3fDUxnrLR/DIqiYEQ85ICqSya8A==",
       "hasInstallScript": true,
       "dependencies": {
         "node-bin-setup": "^1.0.0"
@@ -24269,9 +24269,9 @@
       }
     },
     "node": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-17.1.0.tgz",
-      "integrity": "sha512-1gg810R7sKtFkCYMdIhOyYDCuRJZyLvP+lTX8Z9AMAiUdHPoeNu0KQN59CzBud5L/vMtFPkbsCwWOy1aTYOL8g==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-17.4.0.tgz",
+      "integrity": "sha512-/kPlbyQjDJa9NEOPmKSTmHOxgq+7wAMWNdU+8B9cXseQXTaF3xYAiYc9dCh3fDUxnrLR/DIqiYEQ85ICqSya8A==",
       "requires": {
         "node-bin-setup": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "leaflet-geosearch": "3.6.0",
     "ngx-color-picker": "11.0.0",
     "ngx-infinite-scroll": "10.0.1",
-    "node": "^17.1.0",
+    "node": "^17.4.0",
     "npm": "^8.1.2",
     "openseadragon": "^2.4.2",
     "rxjs": "7.4.0",


### PR DESCRIPTION
The version of node automatically chosen by the node gradle plugin does not support macOS aarch64.

To fix this, a compatible version (17.5.0) has been specified, allowing vitrivr-NG to be built through gradle on macOS aarch64.
