### PR TITLE
Temporal Query Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![GitHub release](https://img.shields.io/github/release/vitrivr/vitrivr-ng?include_prereleases=&sort=semver&color=2ea44f)](https://github.com/vitrivr/vitrivr-ng/releases/)
 [![License](https://img.shields.io/badge/License-MIT-blueviolet)](#license)
 
-[![Build Status](https://travis-ci.org/vitrivr/vitrivr-ng.svg?branch=master)](https://travis-ci.org/vitrivr/vitrivr-ng)
-
 This directory contains the source code distribution of Vitrivr NG (stands for either 'Angular' or 'Next Generation'). It was created using [Angular](https://angular.io/)
 
 Vitrivr NG is a web-based user interface developed to be used with the latest version if [Cineast](https://github.com/vitrivr/cineast). It allows the user to browse in and retrieve from mixed multimedia collections.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitrivr-ng",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/queries/query.service.ts
+++ b/src/app/core/queries/query.service.ts
@@ -33,6 +33,7 @@ import {MediaObjectDescriptor, MediaObjectQueryResult, MediaSegmentDescriptor, M
 import {TemporalQuery} from '../../shared/model/messages/queries/temporal-query.model';
 import {TemporalQueryResult} from '../../shared/model/messages/interfaces/responses/query-result-temporal.interface';
 import MediatypeEnum = MediaObjectDescriptor.MediatypeEnum;
+import {ReadableTemporalQueryConfig} from '../../shared/model/messages/queries/readable-temporal-query-config.model';
 
 /**
  *  Types of changes that can be emitted from the QueryService.
@@ -129,8 +130,8 @@ export class QueryService {
     this._config.configAsObservable.pipe(first()).subscribe(config => {
       const query = new TemporalQuery(
         containers.map(container => new StagedSimilarityQuery(container.stages, null)),
-        new ReadableQueryConfig(null, config.get<Hint[]>('query.config.hints')),
-        null, -1,
+        new ReadableTemporalQueryConfig(null, config.get<Hint[]>('query.config.hints'),
+        null, -1),
         config.metadataAccessSpec);
       this._socket.next(query)
     });
@@ -199,7 +200,11 @@ export class QueryService {
       console.warn('There is already a query running');
     }
     const query = new TemporalQuery(containers.map(container => new StagedSimilarityQuery(container.stages, null)),
-      new ReadableQueryConfig(null, this._config.config.get<Hint[]>('query.config.hints')), timeDistances, maxLength, this._config.config.metadataAccessSpec);
+      new ReadableTemporalQueryConfig(null,
+        this._config.config.get<Hint[]>('query.config.hints'),
+        timeDistances,
+        maxLength),
+      this._config.config.metadataAccessSpec);
     this._socket.next(query)
 
     /** Log Interaction */

--- a/src/app/shared/model/messages/interfaces/requests/temporal-query-config.interface.ts
+++ b/src/app/shared/model/messages/interfaces/requests/temporal-query-config.interface.ts
@@ -1,0 +1,8 @@
+import {Hint} from './query-config.interface';
+
+export interface TemporalQueryConfig {
+  queryId: string;
+  hints: Hint[];
+  timeDistances: number[];
+  maxLength: number;
+}

--- a/src/app/shared/model/messages/interfaces/requests/temporal-query.interface.ts
+++ b/src/app/shared/model/messages/interfaces/requests/temporal-query.interface.ts
@@ -3,7 +3,5 @@ import {MetadataAccessSpecification} from '../../queries/metadata-access-specifi
 
 export interface TemporalQueryMessage {
   queries: StagedSimilarityQuery[];
-  timeDistances: number[];
-  maxLength: number;
   metadataAccessSpec: MetadataAccessSpecification[];
 }

--- a/src/app/shared/model/messages/queries/readable-temporal-query-config.model.ts
+++ b/src/app/shared/model/messages/queries/readable-temporal-query-config.model.ts
@@ -1,0 +1,8 @@
+import {Hint} from '../interfaces/requests/query-config.interface';
+import {TemporalQueryConfig} from '../interfaces/requests/temporal-query-config.interface';
+
+export class ReadableTemporalQueryConfig implements TemporalQueryConfig {
+
+  constructor(public readonly queryId: string = null, public readonly hints: Hint[] = [], public readonly timeDistances: number[] = [], public readonly maxLength: number = -1) {
+  }
+}

--- a/src/app/shared/model/messages/queries/temporal-query.model.ts
+++ b/src/app/shared/model/messages/queries/temporal-query.model.ts
@@ -1,12 +1,12 @@
 import {MessageType} from '../message-type.model';
-import {QueryConfig} from '../interfaces/requests/query-config.interface';
 import {StagedSimilarityQuery} from './staged-similarity-query.model';
 import {TemporalQueryMessage} from '../interfaces/requests/temporal-query.interface';
 import {MetadataAccessSpecification} from './metadata-access-specification.model';
+import {TemporalQueryConfig} from '../interfaces/requests/temporal-query-config.interface';
 
 export class TemporalQuery implements TemporalQueryMessage {
   public readonly messageType: MessageType = 'Q_TEMPORAL';
 
-  constructor(public readonly queries: StagedSimilarityQuery[], public readonly config: QueryConfig = null, public readonly timeDistances: number[] = [], public readonly maxLength: number = -1, public readonly metadataAccessSpec: MetadataAccessSpecification[]) {
+  constructor(public readonly queries: StagedSimilarityQuery[], public readonly config: TemporalQueryConfig = null, public readonly metadataAccessSpec: MetadataAccessSpecification[]) {
   }
 }


### PR DESCRIPTION
Outsourcing config values only relevant for temporal queries into a separate config. Corresponding PR for Cineast: https://github.com/vitrivr/cineast/pull/272