### PR TITLE
Reworking Boolean Query Configuration Options

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,7 +6,7 @@ import {filter, map} from 'rxjs/operators';
 import {MatBottomSheet} from '@angular/material/bottom-sheet';
 import {HistoryComponent} from './results/history.component';
 import {DistinctElementLookupService} from './core/lookup/distinct-element-lookup.service';
-import {ValueType} from './query/containers/bool/bool-attribute';
+import {InputType} from './query/containers/bool/bool-attribute';
 import {SettingsComponent} from './settings/settings.component';
 import {NotificationService} from './core/basics/notification.service';
 import {AppConfig} from './app.config';
@@ -70,8 +70,8 @@ export class AppComponent implements OnInit, AfterViewInit {
   public initLookup(config: Config, distinctLookupService: DistinctElementLookupService) {
     if (config._config.query.options.boolean) {
       config._config.query.boolean.forEach(v => {
-        const type = <number><unknown>ValueType[v[1]];
-        if (type === ValueType.DYNAMICOPTIONS.valueOf()) {
+        const type = <number><unknown>InputType[v[1]];
+        if (type === InputType.DYNAMICOPTIONS.valueOf()) {
           const table: string = v[3];
           const column: string = v[4];
           distinctLookupService.getDistinct(table, column).subscribe()

--- a/src/app/query/containers/bool/individual/bool-term.component.html
+++ b/src/app/query/containers/bool/individual/bool-term.component.html
@@ -1,7 +1,7 @@
 <div [style.display]="'flex'" [style.padding-left]="'10px'" [style.text-align]="'left'" [style.width]="'100%'"
      class="options">
     <!-- Attribute Dropdown -->
-    <mat-select [(ngModel)]="attribute" class="options" required>
+    <mat-select [ngModel]="_attribute | async" (ngModelChange)="_attribute.next($event)" class="options" required>
         <mat-option *ngFor="let attr of possibleAttributes | async"
                     [value]="attr">{{attr.displayName}}</mat-option>
     </mat-select>
@@ -14,10 +14,10 @@
     </div>
 
     <!-- If the current attribute is set, populate operator & value fields -->
-    <ng-container *ngIf="(currentAttributeObservable | async) as currentAttrAsync" class="options">
+    <ng-container *ngIf="(_attribute | async) as currentAttrAsync" class="options">
 
         <!-- Operator dropdown-->
-        <mat-select [(ngModel)]="operatorValue" class="options" required>
+        <mat-select [ngModel]="_operator | async" (ngModelChange)="_operator.next($event)" class="options" required>
             <mat-option *ngFor="let operator of currentAttrAsync.operators" [value]="operator" class="options"
                         style="width:100%">
                 {{operator.toString()}}
@@ -25,33 +25,31 @@
         </mat-select>
 
         <!-- Freetext Field for Numbers & Text -->
-        <mat-form-field *ngIf="currentAttrAsync.valueType.valueOf() === 2 || currentAttrAsync.valueType.valueOf() === 3" class="options">
-            <input [(ngModel)]="inputValue" matInput placeholder="Search text">
+        <mat-form-field *ngIf="currentAttrAsync.inputType.valueOf() === 2 || currentAttrAsync.inputType.valueOf() === 3" class="options">
+            <input [ngModel]="_value | async"
+                   (ngModelChange)="_value.next($event)" matInput placeholder="Search text">
         </mat-form-field>
 
         <!-- Dropdown for Options -->
-        <mat-select *ngIf="currentAttrAsync.valueType.valueOf() === 0 || currentAttrAsync.valueType.valueOf() === 5;" [(ngModel)]="inputValue" class="options" required>
+        <mat-select *ngIf="currentAttrAsync.inputType.valueOf() === 0 || currentAttrAsync.inputType.valueOf() === 5;" [ngModel]="_value | async"
+                    (ngModelChange)="_value.next($event)" class="options" required>
             <mat-option *ngFor="let option of currentAttrAsync.options" [value]="option">
                 {{option}}
             </mat-option>
         </mat-select>
 
         <!-- Date Selector for Date (not yet implemented) -->
-        <mat-form-field *ngIf="currentAttrAsync.valueType.valueOf()==1" class="options textinput">
-            <input [(ngModel)]="inputValue" matInput placeholder="This will be a date selector later">
+        <mat-form-field *ngIf="currentAttrAsync.inputType.valueOf()===1" class="options textinput">
+            <input [ngModel]="_value | async"
+                   (ngModelChange)="_value.next($event)" matInput placeholder="This will be a date selector later">
         </mat-form-field>
 
         <!-- Slider for Range -->
-        <div *ngIf="currentAttrAsync.valueType.valueOf()==4" class="options">
-            <ngx-slider [(highValue)]="maxValue" [(value)]="minValue"
-                        [options]="currentAttrAsync.sliderOptions"></ngx-slider>
+        <div *ngIf="currentAttrAsync.inputType.valueOf()===4" class="options">
+            <ngx-slider [highValue]="_max | async"
+                        (highValueChange)="_max.next($event)" [value]="_min | async"
+                        (valueChange)="_min.next($event)" [options]="currentAttrAsync.sliderOptions"></ngx-slider>
         </div>
-
-        <!-- Traditional Slider
-        <mat-slider class="options" *ngIf="currentAttrAsync.valueType.valueOf()==4"
-                    thumbLabel [displayWith]="formatLabel" tickInterval="auto" min="currentAttrAsync.range[0]" max="currentAttrAsync.range[1]" [(ngModel)]="inputValue">
-        </mat-slider>
-        -->
 
     </ng-container>
 </div>

--- a/src/app/query/containers/query-stage.component.html
+++ b/src/app/query/containers/query-stage.component.html
@@ -1,5 +1,5 @@
-<h3>Stage {{qsList | QueryStageIndexPipe: queryStage}}:</h3>
-<mat-divider>style="padding-bottom:10px"></mat-divider>
+<h3 *ngIf="qsList.length>1">Stage {{qsList | QueryStageIndexPipe: queryStage}}:</h3>
+<mat-divider *ngIf="qsList.length>1">style="padding-bottom:10px"></mat-divider>
 <app-query-component *ngFor="let qt of queryStage.terms" [queryTerm]="qt" [firstStage]="qsList.indexOf(queryStage)==0"
                      [lastStage]="qsList | QueryStageLast: queryStage"
                      [lastInStage]="queryStage.terms.indexOf(qt)==queryStage.terms.length-1"

--- a/src/app/shared/model/config/boolean-query-option.model.ts
+++ b/src/app/shared/model/config/boolean-query-option.model.ts
@@ -1,0 +1,19 @@
+import {BoolOperator, InputType} from '../../../query/containers/bool/bool-attribute';
+import {BooleanQueryValueType} from './boolean-query-types';
+
+export class BooleanQueryOption {
+
+  public constructor(public readonly display: string, public readonly input: InputType, public readonly table: string, public readonly col: string, public readonly range?:[number, number], public readonly options?: any[], public readonly type?: BooleanQueryValueType, public readonly operators?: BoolOperator[]) {
+  }
+
+  public static getInputTypeValue(type: InputType): InputType {
+    let t = -1;
+    if (typeof type == 'string') {
+      t = Number(InputType[type])
+    } else {
+      t = type.valueOf()
+    }
+    return t
+  }
+
+}

--- a/src/app/shared/model/config/boolean-query-types.ts
+++ b/src/app/shared/model/config/boolean-query-types.ts
@@ -1,0 +1,4 @@
+export enum BooleanQueryValueType {
+  number = 1,
+  string = 2
+}

--- a/src/config.json
+++ b/src/config.json
@@ -35,33 +35,44 @@
       ]
     },
     "boolean": [
-      [
-        "Example Freetext",
-        "TEXT",
-        "table_name.text"
-      ],
-      [
-        "Example Dropdown",
-        "OPTIONS",
-        "table_name.option",
-        "ONE",
-        "TWO",
-        "THREE"
-      ],
-      [
-        "Example Range",
-        "RANGE",
-        "table_name.range",
-        5,
-        20
-      ],
-      [
-        "Example Dynamic Options",
-        "DYNAMICOPTIONS",
-        "table_name.option",
-        "table_name",
-        "option"
-      ]
+      {
+        "display": "Example Range",
+        "input": "RANGE",
+        "table": "table",
+        "col": "col",
+        "range": [0, 23]
+      },
+      {
+        "display": "Example Provided Options",
+        "input": "OPTIONS",
+        "table": "table",
+        "col": "col",
+        "options": [
+          "MONDAY",
+          "TUESDAY",
+          "WEDNESDAY",
+          "THURSDAY",
+          "FRIDAY",
+          "SATURDAY",
+          "SUNDAY"
+        ]
+      },
+      {
+        "display": "Example Dynamic Integer Options",
+        "input": "DYNAMICOPTIONS",
+        "table": "tablename",
+        "col": "intcolname",
+        "type": "number"
+      },
+      {
+        "display": "Segment Id",
+        "input": "TEXT",
+        "table": "cineast_segment",
+        "col": "segmentid",
+        "operators": [
+          "="
+        ]
+      }
     ]
   },
   "refinement": {


### PR DESCRIPTION
This PR fixes an issue which was caused due to a recent Cottontail Update, where Integer-Dropdowns would return 0 results because they were sent as strings to Cottontail (and Cottontail doesn't parse Strings in queries as integers anymore if the column which is queried is an integer).

It adds significantly more configuration options to boolean terms (and removes redundancies), allows setting operators explicitly and makes the config more readable. All options are documented via examples in the default configuration. Additionally, https://github.com/vitrivr/cineast/pull/286 adds a working Boolean retrieval for Segment IDs to the default to have an out-of-the-box example.

Additionally, this PR hides information about the stage-index unless there are multiple stage. For a visual diff:

## Previously
![image](https://user-images.githubusercontent.com/14314470/160826026-c116f151-fe49-45f7-9754-bfb44acc8fd8.png)


## Now

![vitrivr-ng-entry](https://user-images.githubusercontent.com/14314470/160825938-c5da6026-6080-4959-95d6-0508e66aaa53.png)
