### PR TITLE
Adding ability to view metadata when loading segment details

### DIFF
--- a/src/app/objectdetails/objectdetails.component.css
+++ b/src/app/objectdetails/objectdetails.component.css
@@ -1,3 +1,7 @@
+table {
+    width: 100%;
+}
+
 .tile {
     width: 200px;
     height: 200px;

--- a/src/app/segmentdetails/segment-features.component.html
+++ b/src/app/segmentdetails/segment-features.component.html
@@ -49,5 +49,17 @@
                 {{ocr}}
             </div>
         </mat-tab>
+        <mat-tab *ngIf="_meta.length>0" label="Metadata">
+
+            <table mat-table [dataSource]="_meta">
+                <ng-container matColumnDef="{{meta}}" *ngFor="let meta of metaCols">
+                    <th mat-header-cell *matHeaderCellDef> {{meta}}</th>
+                    <td mat-cell *matCellDef="let detailElement"> {{detailElement[meta]}} </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="metaCols"></tr>
+                <tr mat-row *matRowDef="let detailRow; columns: metaCols;"></tr>
+            </table>
+        </mat-tab>
     </mat-tab-group>
 </div>

--- a/src/app/segmentdetails/segment-features.component.ts
+++ b/src/app/segmentdetails/segment-features.component.ts
@@ -1,5 +1,5 @@
 import {Component, ViewChild} from '@angular/core';
-import {MediaSegmentDescriptor, MetadataService, Tag, TagService} from '../../../openapi/cineast';
+import {MediaSegmentDescriptor, MediaSegmentMetadataDescriptor, MediaSegmentMetadataQueryResult, MetadataService, Tag, TagService} from '../../../openapi/cineast';
 import {ContextKey, InteractionEventComponent} from '../shared/model/events/interaction-event-component.model';
 import {InteractionEvent} from '../shared/model/events/interaction-event.model';
 import {InteractionEventType} from '../shared/model/events/interaction-event-type.model';
@@ -15,11 +15,13 @@ export class SegmentFeaturesComponent {
   @ViewChild('segmentFeaturesComponent')
   segmentFeaturesComponent: SegmentFeaturesComponent;
 
+  metaCols = ['domain', 'key', 'value']
   segmentId: string
   _tags: Tag[] = [];
   _captions: string[] = [];
   _asr: string[] = [];
   _ocr: string[] = [];
+  _meta: MediaSegmentMetadataDescriptor[] = [];
 
   constructor(private _eventBusService: EventBusService, private _metaService: MetadataService, private _tagService: TagService) {
   }
@@ -49,5 +51,7 @@ export class SegmentFeaturesComponent {
     this._metaService.findTextByIDAndCat(segment.segmentId, 'asr').subscribe(asr => this._asr = asr.featureValues);
     // get the OCR data associated with a segmentId
     this._metaService.findTextByIDAndCat(segment.segmentId, 'ocr').subscribe(ocr => this._ocr = ocr.featureValues);
+
+    this._metaService.findSegMetaById(segment.segmentId).subscribe(meta => this._meta = meta.content)
   }
 }

--- a/src/app/segmentdetails/segmentfeatures.module.ts
+++ b/src/app/segmentdetails/segmentfeatures.module.ts
@@ -6,12 +6,12 @@ import {M3DLoaderModule} from '../shared/components/m3d/m3d-loader-module';
 
 import {MaterialModule} from '../material.module';
 import {AdvancedMediaPlayerModule} from '../shared/components/video/advanced-video-player.module';
-import {SegmentdetailsComponent} from './segmentdetails.component';
 import {SegmentFeaturesComponent} from './segment-features.component';
 import {PipesModule} from '../shared/pipes/pipes.module';
+import {MatTableModule} from '@angular/material/table';
 
 @NgModule({
-  imports: [MaterialModule, FlexLayoutModule, BrowserModule, AppRoutingModule, M3DLoaderModule, AdvancedMediaPlayerModule, PipesModule],
+  imports: [MaterialModule, FlexLayoutModule, BrowserModule, AppRoutingModule, M3DLoaderModule, AdvancedMediaPlayerModule, PipesModule, MatTableModule],
   declarations: [SegmentFeaturesComponent],
   exports: [SegmentFeaturesComponent],
 })


### PR DESCRIPTION
With this PR, metadata for a segment is shown alongside tags, OCR etc. when clicking on the `Load Features` Button. Currently, the metadata is only viewable through the `?` button, which disappears after a few seconds.

![image](https://user-images.githubusercontent.com/14314470/168477115-f2f3fa72-80c4-41ac-8ad1-7d3bc2b2eaba.png)