### PR TITLE
Adding ability to sort object view either by time or by score

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7442,12 +7442,12 @@
       "dev": true
     },
     "node_modules/ejs": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-      "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
       "dev": true,
       "dependencies": {
-        "jake": "^10.6.1"
+        "jake": "^10.8.5"
       },
       "bin": {
         "ejs": "bin/cli.js"
@@ -8539,12 +8539,33 @@
       }
     },
     "node_modules/filelist": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
-      "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "dev": true,
       "dependencies": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -9815,12 +9836,12 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.8.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.4.tgz",
-      "integrity": "sha512-MtWeTkl1qGsWUtbl/Jsca/8xSoK3x0UmS82sNbjqxxG/de/M/3b1DntdjHgPMC50enlTNwXOCRqPXLLt5cCfZA==",
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
       "dev": true,
       "dependencies": {
-        "async": "0.9.x",
+        "async": "^3.2.3",
         "chalk": "^4.0.2",
         "filelist": "^1.0.1",
         "minimatch": "^3.0.4"
@@ -9848,9 +9869,9 @@
       }
     },
     "node_modules/jake/node_modules/async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
       "dev": true
     },
     "node_modules/jake/node_modules/chalk": {
@@ -23617,12 +23638,12 @@
       "dev": true
     },
     "ejs": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-      "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
+      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
       "dev": true,
       "requires": {
-        "jake": "^10.6.1"
+        "jake": "^10.8.5"
       }
     },
     "electron-to-chromium": {
@@ -24366,12 +24387,32 @@
       }
     },
     "filelist": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
-      "integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
       "dev": true,
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "^5.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "fill-range": {
@@ -25313,12 +25354,12 @@
       "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q=="
     },
     "jake": {
-      "version": "10.8.4",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.4.tgz",
-      "integrity": "sha512-MtWeTkl1qGsWUtbl/Jsca/8xSoK3x0UmS82sNbjqxxG/de/M/3b1DntdjHgPMC50enlTNwXOCRqPXLLt5cCfZA==",
+      "version": "10.8.5",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
+      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
       "dev": true,
       "requires": {
-        "async": "0.9.x",
+        "async": "^3.2.3",
         "chalk": "^4.0.2",
         "filelist": "^1.0.1",
         "minimatch": "^3.0.4"
@@ -25334,9 +25375,9 @@
           }
         },
         "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+          "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
           "dev": true
         },
         "chalk": {

--- a/src/app/objectdetails/objectdetails.component.css
+++ b/src/app/objectdetails/objectdetails.component.css
@@ -5,6 +5,8 @@ table {
 .tile {
     width: 200px;
     height: 200px;
+    border-top:10px solid;
+    border-bottom:10px solid;
     margin-bottom: 25px;
     box-shadow: 0.15em 0.15em 0.05em 0 rgba(0, 0, 0, 0.4); /* The top layer shadow */
     position: relative;

--- a/src/app/objectdetails/objectdetails.component.html
+++ b/src/app/objectdetails/objectdetails.component.html
@@ -5,6 +5,11 @@
 <div *ngIf="_mediaObject as obj" style="padding:10px;">
     <app-objectviewer #objectviewerComponent [mediaobject]="obj"></app-objectviewer>
 
+    <mat-button-toggle-group name="orderType" aria-label="Order By" [value]="orderTypeStr" (change)="onOrderTypeChange($event.value)" >
+        <mat-button-toggle value="score">Score</mat-button-toggle>
+        <mat-button-toggle value="time">Time</mat-button-toggle>
+    </mat-button-toggle-group>
+
     <div *ngIf="_mediaObject._segmentsObservable |async as segments">
 
         <mat-tab-group>

--- a/src/app/objectdetails/objectdetails.component.html
+++ b/src/app/objectdetails/objectdetails.component.html
@@ -17,7 +17,7 @@
                 <div fxLayout="row" fxLayoutGap="5px" fxLayoutWrap="wrap">
                     <div (dragstart)="onSegmentDrag($event, segment)"
                          *ngFor="let segment of (segments | orderBy:orderType)" class="tile"
-                         draggable="true" fxFlex="200px">
+                         draggable="true" fxFlex="200px" [style.border-top-color]="segment.score | BackgroundScorePipe:segment:[]" [style.border-bottom-color]="segment.score | BackgroundScorePipe:segment:[]">
                         <div class="tile-header" fxLayout fxLayoutAlign="space-between start">
                             <p [style.margin]="'0'">{{segment.segmentId}} ({{segment._score | ScorePercentagePipe}}&#37;)</p>
                             <p *ngIf="segment.endabs > 0" [style.margin]="'0'">{{segment.startabs.toFixed(2)}}

--- a/src/app/objectdetails/objectdetails.component.ts
+++ b/src/app/objectdetails/objectdetails.component.ts
@@ -44,9 +44,9 @@ export class ObjectdetailsComponent implements OnInit {
   _showSubmitButton = false
   _loading = false
 
-  private _lsc = false;
   /** Currently selected objectID */
   private objectIdObservable: Observable<string>;
+  orderTypeStr: string;
 
   constructor(private _route: ActivatedRoute,
               private _snackBar: MatSnackBar,
@@ -61,17 +61,7 @@ export class ObjectdetailsComponent implements OnInit {
               private _segmentService: SegmentService,
               private _config: AppConfig,
               private readonly _vbs: VbsSubmissionService) {
-
-    _config.configAsObservable.subscribe(config => {
-      this._lsc = config.get<boolean>('competition.lsc');
-      if (this._lsc) {
-        this.orderType = OrderType.SEGMENT_ID
-      } else {
-        this.orderType = OrderType.SCORE;
-      }
-    });
     _vbs.isOn.subscribe(res => this._showSubmitButton = res);
-
 
     /** Generate observables required to create the view. */
     this.objectIdObservable = _route.params.pipe(
@@ -86,7 +76,9 @@ export class ObjectdetailsComponent implements OnInit {
      */
     if (!this._query.results) {
       this._container = new MediaObjectScoreContainer(undefined);
-      this.orderType = OrderType.SEGMENT_TIME;
+      this.setOrderType(OrderType.SEGMENT_TIME)
+    }else{
+      this.setOrderType(OrderType.SCORE)
     }
 
     this.objectIdObservable.pipe(
@@ -144,6 +136,8 @@ export class ObjectdetailsComponent implements OnInit {
       })
     ).subscribe()
   }
+
+
 
   /**
    * Event Handler: Whenever a segment is dragged, that segment is converted to JSON and added to the dataTransfer
@@ -218,5 +212,28 @@ export class ObjectdetailsComponent implements OnInit {
   public onSubmitPressed(segment: MediaSegmentScoreContainer) {
     console.debug(`submitting for segment ${segment.segmentId}`);
     this._vbs.submitSegment(segment)
+  }
+
+  onOrderTypeChange(value: string) {
+    switch (value) {
+      case 'score':
+        this.orderType = OrderType.SCORE
+        break;
+      case 'time':
+        this.orderType = OrderType.SEGMENT_TIME
+        break;
+    }
+  }
+
+  private setOrderType(type: OrderType) {
+    this.orderType = type
+    switch(type){
+      case OrderType.SCORE:
+        this.orderTypeStr = 'score'
+        break;
+      case OrderType.SEGMENT_TIME:
+        this.orderTypeStr = 'time'
+        break;
+    }
   }
 }

--- a/src/app/objectdetails/objectdetails.module.ts
+++ b/src/app/objectdetails/objectdetails.module.ts
@@ -12,9 +12,10 @@ import {AdvancedMediaPlayerModule} from '../shared/components/video/advanced-vid
 import {MetadataDetailsComponent} from './metadata-details.component';
 import {ObjectviewerComponent} from './objectviewer.component';
 import {SegmentfeaturesModule} from '../segmentdetails/segmentfeatures.module';
+import {MatButtonToggleModule} from '@angular/material/button-toggle';
 
 @NgModule({
-  imports: [MaterialModule, FlexLayoutModule, BrowserModule, AppRoutingModule, M3DLoaderModule, PipesModule, AdvancedMediaPlayerModule, SegmentfeaturesModule],
+  imports: [MaterialModule, FlexLayoutModule, BrowserModule, AppRoutingModule, M3DLoaderModule, PipesModule, AdvancedMediaPlayerModule, SegmentfeaturesModule, MatButtonToggleModule],
   declarations: [ObjectdetailsComponent, QuickViewerComponent, MetadataDetailsComponent, ObjectviewerComponent],
   exports: [ObjectdetailsComponent, QuickViewerComponent, MetadataDetailsComponent, ObjectviewerComponent],
 })

--- a/src/app/objectdetails/objectviewer.component.html
+++ b/src/app/objectdetails/objectviewer.component.html
@@ -2,7 +2,7 @@
     <button (click)="onBackClick()" mat-icon-button matTooltip="Go back...">
         <mat-icon>keyboard_backspace</mat-icon>
     </button>
-    <h2 [style.margin-top]="'5px'">&nbsp;Media object: {{mediaobject.objectId}}</h2>
+    <h2 [style.margin-top]="'5px'">&nbsp;Media object: {{mediaobject.objectid}}</h2>
 </div>
 
 <div [style.display]="'flex'" [style.justify-content]="'flex-start'">

--- a/src/app/shared/pipes/containers/order-by.pipe.ts
+++ b/src/app/shared/pipes/containers/order-by.pipe.ts
@@ -6,21 +6,21 @@ import {OrderBySegmentIdPipe} from './order-by-segment-id.pipe';
 
 export enum OrderType {
   /**
-   * Type to use OrderByScorePipe (actually order the segments by their score
+   * Type to use OrderByScorePipe (actually order the segments by their score)
    */
   SCORE,
   /**
-   * Type to use OrderBySegmenPipe (actually orders the segments by their time values
+   * Type to use OrderBySegmenPipe (actually orders the segments by their time values)
    */
   SEGMENT_TIME,
   /**
-   * Type to use OrderBySegmentIdPipe (actually orders the segments by their id
+   * Type to use OrderBySegmentIdPipe (actually orders the segments by their id)
    */
   SEGMENT_ID
 }
 
 /**
- * A pipe which can take an agrument to which sorting it shoud use
+ * A pipe which can take an argument to which sorting it should use
  */
 @Pipe({name: 'orderBy'})
 export class OrderByPipe implements PipeTransform {


### PR DESCRIPTION
Currently, the object view is only sorted one way. This can be annoying for objects with a large amount of segments (e.g. in the lsc context). @benzvera suggested having both options (by segment time and score) and this PR implements that.

By Score:

![image](https://user-images.githubusercontent.com/14314470/168478219-370f9e24-c13a-411e-8747-72ea23be4f4b.png)

By Time:

![image](https://user-images.githubusercontent.com/14314470/168478232-edddb727-855d-4868-97c9-f604382a264c.png)
